### PR TITLE
fix model multi-line string comment behavior

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -71,6 +71,14 @@ func createTable(db *DBO) (*DBO, error) {
 	if err != nil {
 		return db, err
 	}
+	_, err = db.Exec("comment on column apple_attribute.id is 'column id - single line comment';")
+	if err != nil {
+		return db, err
+	}
+	_, err = db.Exec("comment on column apple_attribute.code is 'column code - multi\nline\r\ncomment';")
+	if err != nil {
+		return db, err
+	}
 	_, err = db.Exec("insert into apple_attribute (code) values ('one'), ('two')")
 	return db, err
 }

--- a/generator.go
+++ b/generator.go
@@ -365,6 +365,9 @@ func getHelperFunc(systemColumns SystemColumns) template.FuncMap {
 			}
 			return modelType
 		},
+		"splitByNewline": func(text string) []string {
+			return strings.Split(strings.Replace(text, "\r\n", "\n", -1), "\n")
+		},
 	}
 }
 

--- a/modelx.tmpl
+++ b/modelx.tmpl
@@ -9,7 +9,8 @@ import (
 {{ $index := 0 }}{{ $comma := 0 }}{{ $isSoft := false }}
 // {{ .Model }} model
 type {{ .Model }} struct { {{ range $key, $column := .Columns }}
-    {{ if $column.Description }}// {{ $column.Description }}{{ end }}
+    {{ if $column.Description }}{{ range splitByNewline $column.Description }}
+    // {{.}}{{ end }}{{ end }}
     {{ $column.ModelName }} {{ if or $column.IsArray $column.IsByteArray }} {{ $column.ModelType }} {{ else }} {{ pointerType $column.ModelType }} {{ end }} {{ $column.Tags }} {{ end }}
 }
 


### PR DESCRIPTION
Hello.

Fix model multi-line string comment behavior

For example if we have table column with comment:
"comment on column apple_attribute.code is 'column code - multi
line
comment'"

it's generate a wrong models/TABLE.go model file

Best Regards, Ilya Pavlov
